### PR TITLE
feat : File Service & KaKao Login

### DIFF
--- a/src/main/java/com/umc/drawmap/controller/OauthUserController.java
+++ b/src/main/java/com/umc/drawmap/controller/OauthUserController.java
@@ -40,15 +40,11 @@ public class OauthUserController {
         this.customOAuth2UserService = customOAuth2UserService;
     }
 
-
-    // 카카오 로그인.
-    @GetMapping("/oauth2/kakao")
-    public String getAccessToken(@RequestParam("code") String code) throws ParseException {
-        System.out.println("code = " + code);
-
-
-
-
+    // 카카오 토큰을 가져 오는 과정을 하나로 합쳐 두었습니다.
+    @ResponseBody
+    @GetMapping("/callback")
+    public String kakaoCallback(@RequestParam String code) throws ParseException {
+        System.out.println(code);
         // 1. header 생성
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.add(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded;charset=utf-8");
@@ -83,14 +79,6 @@ public class OauthUserController {
         token.put("refresh_token", refreshToken);
 
         return token.toString();
-    }
-    // 인가코드 받아오기
-    @ResponseBody
-    @GetMapping("/callback")
-    public BaseResponse<String> kakaoCallback(@RequestParam String code){
-        String response = "성공적으로 카카오 로그인 API 코드를 불러왔습니다.";
-        System.out.println(code);
-        return new BaseResponse<>(response);
     }
 
     // KaKao Access Token => 로그인 => JWT 발급.

--- a/src/main/java/com/umc/drawmap/service/ChallengeService.java
+++ b/src/main/java/com/umc/drawmap/service/ChallengeService.java
@@ -34,9 +34,12 @@ public class ChallengeService {
     private final UserChallengeRepository userChallengeRepository;
     private final UserRepository userRepository;
     private final SpotImageRepository spotImageRepository;
+    private final S3FileService s3FileService;
 
     @Transactional
     public Challenge create(List<MultipartFile> files, ChallengeReqDto.CreateChallengeDto request) throws IOException{
+
+
 
         Challenge challenge = Challenge.builder()
                 .challengeCourseTitle(request.getChallengeCourseTitle())
@@ -44,7 +47,7 @@ public class ChallengeService {
                 .sgg(request.getSgg())
                 .challengeCourseContent(request.getChallengeCourseContent())
                 .challengeCourseDifficulty(request.getChallengeCourseDifficulty())
-                .challengeImage(FileService.fileUpload(files))
+                .challengeImage(s3FileService.upload(files)) // S3 로 수정.
                 .build();
 
         return challengeRepository.save(challenge);
@@ -53,7 +56,7 @@ public class ChallengeService {
     public Challenge update(Long challengeId,List<MultipartFile> files, ChallengeReqDto.UpdateChallengeDto request) throws IOException{
         Challenge challenge = challengeRepository.findById(challengeId)
                 .orElseThrow(() -> new NotFoundException("도전코스를 찾을 수 없습니다."));
-        challenge.update(request.getChallengeCourseTitle(), request.getSido(), request.getSgg(), request.getChallengeCourseDifficulty(), request.getChallengeCourseContent(), FileService.fileUpload(files));
+        challenge.update(request.getChallengeCourseTitle(), request.getSido(), request.getSgg(), request.getChallengeCourseDifficulty(), request.getChallengeCourseContent(), s3FileService.upload(files));
         return challenge;
     }
 

--- a/src/main/java/com/umc/drawmap/service/S3FileService.java
+++ b/src/main/java/com/umc/drawmap/service/S3FileService.java
@@ -27,7 +27,7 @@ public class S3FileService {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    public String upload(List<MultipartFile> files) { // 더 수정하기 (컨트롤러 , DTO, DB)
+    public String upload(List<MultipartFile> files) {
 
         // S3 에 저장 되는 파일 이름은  업로드 시각 + 유저 이름 으로 하자.
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

--- a/src/main/java/com/umc/drawmap/service/UserCourseService.java
+++ b/src/main/java/com/umc/drawmap/service/UserCourseService.java
@@ -32,6 +32,7 @@ public class UserCourseService {
     private final UserRepository userRepository;
 
     private final ChallengeRepository challengeRepository;
+    private final S3FileService s3FileService;
     @Transactional
     public UserCourse create(List<MultipartFile> files, UserCourseReqDto.CreateUserCourseDto request, Principal principal) throws IOException {
         User user = userRepository.findByNickName(principal.getName())
@@ -44,7 +45,7 @@ public class UserCourseService {
                 .userCourseContent(request.getUserCourseContent())
                 .userCourseComment(request.getUserCourseComment())
                 .userCourseDifficulty(request.getUserCourseDifficulty())
-                .userImage(FileService.fileUpload(files))
+                .userImage(s3FileService.upload(files))
                 .user(user)
                 .build();
 
@@ -56,7 +57,7 @@ public class UserCourseService {
                 .orElseThrow(()-> new NotFoundException("유저개발코스를 찾을 수 없습니다."));
         userCourse.update(request.getUserCourseTitle(), request.getSido(), request.getSgg(),
                 request.getUserCourseDifficulty(), request.getUserCourseContent(),
-                request.getUserCourseComment(), FileService.fileUpload(files));
+                request.getUserCourseComment(), s3FileService.upload(files));
         return userCourse;
     }
 


### PR DESCRIPTION
1. S3 파일 서비스를 구현후, Challenge / User Corse 에 적용하였습니다.
2. KaKao Login 의 단계를 줄였습니다.
기존에는 카카오 로그인 이후 얻어진 코드를 다시 대입하여 access_code 를 발급받아 사용하였지만,
카카오 로그인 이후 바로 access_code 를 발급받을 수 있도록 하였습니다. (jwt 가 아닌 kakao 의 access_code)